### PR TITLE
Example: add queryReferenceCellSets component by copying cellSets component

### DIFF
--- a/src/app/component-registry.js
+++ b/src/app/component-registry.js
@@ -13,6 +13,7 @@ import CellSetSizesPlotSubscriber from '../components/sets/CellSetSizesPlotSubsc
 import GenomicProfilesSubscriber from '../components/higlass/GenomicProfilesSubscriber';
 import ExpressionHistogramSubscriber from '../components/genes/ExpressionHistogramSubscriber';
 import CellSetExpressionPlotSubscriber from '../components/sets/CellSetExpressionPlotSubscriber';
+import QRCellSetsTableSubscriber from '../components/sets/QRCellSetsTableSubscriber';
 
 
 const registry = {
@@ -28,6 +29,7 @@ const registry = {
   [Component.GENOMIC_PROFILES]: GenomicProfilesSubscriber,
   [Component.EXPRESSION_HISTOGRAM]: ExpressionHistogramSubscriber,
   [Component.CELL_SET_EXPRESSION]: CellSetExpressionPlotSubscriber,
+  [Component.QUERY_REFERENCE_CELL_SETS]: QRCellSetsTableSubscriber,
   // The plain higlass component does not abstract away the HiGlass view config,
   // so we probably want to avoid documenting it, only use it for development purposes.
   higlass: HiGlassSubscriber,

--- a/src/app/constants.js
+++ b/src/app/constants.js
@@ -11,6 +11,7 @@ export const Component = {
   GENOMIC_PROFILES: 'genomicProfiles',
   CELL_SET_EXPRESSION: 'cellSetExpression',
   EXPRESSION_HISTOGRAM: 'expressionHistogram',
+  QUERY_REFERENCE_CELL_SETS: 'queryReferenceCellSets',
 };
 
 export const DataType = {

--- a/src/app/state/coordination.js
+++ b/src/app/state/coordination.js
@@ -173,6 +173,15 @@ export const COMPONENT_COORDINATION_TYPES = {
     CoordinationType.ADDITIONAL_CELL_SETS,
     CoordinationType.GENE_SELECTION,
   ],
+  [Component.QUERY_REFERENCE_CELL_SETS]: [
+    CoordinationType.DATASET,
+    CoordinationType.CELL_SET_SELECTION,
+    CoordinationType.CELL_SET_HIGHLIGHT,
+    CoordinationType.CELL_SET_COLOR,
+    CoordinationType.CELL_COLOR_ENCODING,
+    CoordinationType.ADDITIONAL_CELL_SETS,
+    CoordinationType.GENE_SELECTION,
+  ],
   [Component.CELL_SET_SIZES]: [
     CoordinationType.DATASET,
     CoordinationType.CELL_SET_SELECTION,

--- a/src/components/sets/QRCellSetsTable.js
+++ b/src/components/sets/QRCellSetsTable.js
@@ -1,0 +1,292 @@
+/* eslint-disable */
+/* eslint-disable no-underscore-dangle */
+/* Originally copied from SetsManager.js */
+import React, { useState, useMemo } from 'react';
+import isEqual from 'lodash/isEqual';
+import Tree from './Tree';
+import TreeNode from './TreeNode';
+import { PlusButton, SetOperationButtons } from './SetsManagerButtons';
+import { nodeToRenderProps } from './cell-set-utils';
+import { getDefaultColor } from '../utils';
+import { pathToKey } from './utils';
+
+function processNode(node, prevPath, setColor, theme) {
+  const nodePath = [...prevPath, node.name];
+  return {
+    ...node,
+    ...(node.children ? ({
+      children: node.children
+        .map(c => processNode(c, nodePath, setColor)),
+    }) : {}),
+    color: setColor?.find(d => isEqual(d.path, nodePath))?.color || getDefaultColor(theme),
+  };
+}
+
+function processSets(sets, setColor, theme) {
+  return {
+    ...sets,
+    tree: sets ? sets.tree.map(lzn => processNode(lzn, [], setColor, theme)) : [],
+  };
+}
+
+function getAllKeys(node, path = []) {
+  if (!node) {
+    return null;
+  }
+  const newPath = [...path, node.name];
+  if (node.children) {
+    return [pathToKey(newPath), ...node.children.flatMap(v => getAllKeys(v, newPath))];
+  }
+  return pathToKey(newPath);
+}
+
+/**
+ * A generic hierarchical set manager component.
+ * @prop {object} tree An object representing set hierarchies.
+ * @prop {string} datatype The data type for sets (e.g. "cell")
+ * @prop {function} clearPleaseWait A callback to signal that loading is complete.
+ * @prop {boolean} draggable Whether tree nodes can be rearranged via drag-and-drop.
+ * By default, true.
+ * @prop {boolean} checkable Whether to show the "Check" menu button
+ * and checkboxes for selecting multiple sets. By default, true.
+ * @prop {boolean} editable Whether to show rename, delete, color, or create options.
+ * By default, true.
+ * @prop {boolean} expandable Whether to allow hierarchies to be expanded
+ * to show the list or tree of sets contained. By default, true.
+ * @prop {boolean} operatable Whether to enable union, intersection,
+ * and complement operations on checked sets. By default, true.
+ * @prop {boolean} exportable Whether to enable exporting hierarchies and sets to files.
+ * By default, true.
+ * @prop {boolean} importable Whether to enable importing hierarchies from files.
+ * By default, true.
+ * @prop {function} onError Function to call with error messages (failed import validation, etc).
+ * @prop {function} onCheckNode Function to call when a single node has been checked or un-checked.
+ * @prop {function} onExpandNode Function to call when a node has been expanded.
+ * @prop {function} onDropNode Function to call when a node has been dragged-and-dropped.
+ * @prop {function} onCheckLevel Function to call when an entire hierarchy level has been selected,
+ * via the "Color by cluster" and "Color by subcluster" buttons below collapsed level zero nodes.
+ * @prop {function} onNodeSetColor Function to call when a new node color has been selected.
+ * @prop {function} onNodeSetName Function to call when a node has been renamed.
+ * @prop {function} onNodeRemove Function to call when the user clicks the "Delete" menu button
+ * to remove a node.
+ * @prop {function} onNodeView Function to call when the user wants to view the set associated
+ * with a particular node.
+ * @prop {function} onImportTree Function to call when a tree has been imported
+ * using the "plus" button.
+ * @prop {function} onCreateLevelZeroNode Function to call when a user clicks the "Create hierarchy"
+ * menu option using the "plus" button.
+ * @prop {function} onExportLevelZeroNode Function to call when a user wants to
+ * export an entire hierarchy via the "Export hierarchy" menu button for a
+ * particular level zero node.
+ * @prop {function} onExportSet Function to call when a user wants to export a set associated with
+ * a particular node via the "Export set" menu button.
+ * @prop {function} onUnion Function to call when a user wants to create a new set from the union
+ * of the sets associated with the currently-checked nodes.
+ * @prop {function} onIntersection Function to call when a user wants to create a new set from the
+ * intersection of the sets associated with the currently-checked nodes.
+ * @prop {function} onComplement Function to call when a user wants to create a new set from the
+ * complement of the (union of the) sets associated with the currently-checked nodes.
+ * @prop {function} onView Function to call when a user wants to view the sets
+ * associated with the currently-checked nodes.
+ * @prop {string} theme "light" or "dark" for the vitessce theme
+ */
+export default function QRCellSetsTable(props) {
+  const {
+    theme,
+    sets,
+    additionalSets,
+    setColor, // TODO: use this
+    levelSelection: checkedLevel,
+    setSelection,
+    setExpansion,
+    hasColorEncoding,
+    datatype,
+    draggable = true,
+    checkable = true,
+    editable = true,
+    expandable = true,
+    operatable = true,
+    exportable = true,
+    importable = true,
+    onError,
+    onCheckNode,
+    onExpandNode,
+    onDropNode,
+    onCheckLevel,
+    onNodeSetColor,
+    onNodeSetName,
+    onNodeCheckNewName,
+    onNodeRemove,
+    onNodeView,
+    onImportTree,
+    onCreateLevelZeroNode,
+    onExportLevelZeroNodeJSON,
+    onExportLevelZeroNodeTabular,
+    onExportSetJSON,
+    onUnion,
+    onIntersection,
+    onComplement,
+    hasCheckedSetsToUnion,
+    hasCheckedSetsToIntersect,
+    hasCheckedSetsToComplement,
+  } = props;
+
+  const isChecking = true;
+  const autoExpandParent = true;
+  const [isDragging, setIsDragging] = useState(false);
+  const [isEditingNodeName, setIsEditingNodeName] = useState(null);
+
+  const processedSets = useMemo(() => processSets(
+    sets, setColor, theme,
+  ), [sets, setColor, theme]);
+  const processedAdditionalSets = useMemo(() => processSets(
+    additionalSets, setColor, theme,
+  ), [additionalSets, setColor, theme]);
+
+  const additionalSetKeys = (processedAdditionalSets
+    ? processedAdditionalSets.tree.flatMap(v => getAllKeys(v, []))
+    : []
+  );
+
+  const allSetSelectionKeys = (setSelection || []).map(pathToKey);
+  const allSetExpansionKeys = (setExpansion || []).map(pathToKey);
+
+  const setSelectionKeys = allSetSelectionKeys.filter(k => !additionalSetKeys.includes(k));
+  const setExpansionKeys = allSetExpansionKeys.filter(k => !additionalSetKeys.includes(k));
+
+  const additionalSetSelectionKeys = allSetSelectionKeys.filter(k => additionalSetKeys.includes(k));
+  const additionalSetExpansionKeys = allSetExpansionKeys.filter(k => additionalSetKeys.includes(k));
+
+  /**
+   * Recursively render TreeNode components.
+   * @param {object[]} nodes An array of node objects.
+   * @returns {TreeNode[]|null} Array of TreeNode components or null.
+   */
+  function renderTreeNodes(nodes, readOnly, currPath) {
+    if (!nodes) {
+      return null;
+    }
+    return nodes.map((node) => {
+      const newPath = [...currPath, node.name];
+      return (
+        <TreeNode
+          theme={theme}
+          key={pathToKey(newPath)}
+          {...nodeToRenderProps(node, newPath, setColor)}
+
+          isEditing={isEqual(isEditingNodeName, newPath)}
+
+          datatype={datatype}
+          draggable={draggable && !readOnly}
+          editable={editable && !readOnly}
+          checkable={checkable}
+          expandable={expandable}
+          exportable={exportable}
+
+          hasColorEncoding={hasColorEncoding}
+          isChecking={isChecking}
+          checkedLevelPath={checkedLevel ? checkedLevel.levelZeroPath : null}
+          checkedLevelIndex={checkedLevel ? checkedLevel.levelIndex : null}
+
+          onCheckNode={onCheckNode}
+          onCheckLevel={onCheckLevel}
+          onNodeView={onNodeView}
+          onNodeSetColor={onNodeSetColor}
+          onNodeSetName={(targetPath, name) => {
+            onNodeSetName(targetPath, name);
+            setIsEditingNodeName(null);
+          }}
+          onNodeCheckNewName={onNodeCheckNewName}
+          onNodeSetIsEditing={setIsEditingNodeName}
+          onNodeRemove={onNodeRemove}
+          onExportLevelZeroNodeJSON={onExportLevelZeroNodeJSON}
+          onExportLevelZeroNodeTabular={onExportLevelZeroNodeTabular}
+          onExportSetJSON={onExportSetJSON}
+
+          disableTooltip={isDragging}
+          onDragStart={() => setIsDragging(true)}
+          onDragEnd={() => setIsDragging(false)}
+        >
+          {renderTreeNodes(node.children, readOnly, newPath, theme)}
+        </TreeNode>
+      );
+    });
+  }
+
+  return (
+    <div className="sets-manager">
+      <p>New table component here</p>
+      <div className="sets-manager-tree">
+        <Tree
+          draggable={false}
+          checkable={checkable}
+
+          checkedKeys={setSelectionKeys}
+          expandedKeys={setExpansionKeys}
+          autoExpandParent={autoExpandParent}
+
+          onCheck={(checkedKeys, info) => onCheckNode(
+            info.node.props.nodeKey,
+            info.checked,
+          )}
+          onExpand={(expandedKeys, info) => onExpandNode(
+            expandedKeys,
+            info.node.props.nodeKey,
+            info.expanded,
+          )}
+        >
+          {renderTreeNodes(processedSets.tree, true, [], theme)}
+        </Tree>
+        <Tree
+          draggable
+          checkable={checkable}
+
+          checkedKeys={additionalSetSelectionKeys}
+          expandedKeys={additionalSetExpansionKeys}
+          autoExpandParent={autoExpandParent}
+
+          onCheck={(checkedKeys, info) => onCheckNode(
+            info.node.props.nodeKey,
+            info.checked,
+          )}
+          onExpand={(expandedKeys, info) => onExpandNode(
+            expandedKeys,
+            info.node.props.nodeKey,
+            info.expanded,
+          )}
+          onDrop={(info) => {
+            const { eventKey: dropKey } = info.node.props;
+            const { eventKey: dragKey } = info.dragNode.props;
+            const { dropToGap, dropPosition } = info;
+            onDropNode(dropKey, dragKey, dropPosition, dropToGap);
+          }}
+        >
+          {renderTreeNodes(processedAdditionalSets.tree, false, [], theme)}
+        </Tree>
+
+        <PlusButton
+          datatype={datatype}
+          onError={onError}
+          onImportTree={onImportTree}
+          onCreateLevelZeroNode={onCreateLevelZeroNode}
+          importable={importable}
+          editable={editable}
+        />
+        </div>
+      {isChecking ? (
+        <div className="set-operation-buttons">
+          <SetOperationButtons
+            onUnion={onUnion}
+            onIntersection={onIntersection}
+            onComplement={onComplement}
+            operatable={operatable}
+
+            hasCheckedSetsToUnion={hasCheckedSetsToUnion}
+            hasCheckedSetsToIntersect={hasCheckedSetsToIntersect}
+            hasCheckedSetsToComplement={hasCheckedSetsToComplement}
+          />
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/sets/QRCellSetsTableSubscriber.js
+++ b/src/components/sets/QRCellSetsTableSubscriber.js
@@ -1,0 +1,635 @@
+/* eslint-disable */
+/* Originally copied from CellSetsManagerSubscriber.js */
+import React, {
+  useEffect,
+  useState,
+  useMemo,
+} from 'react';
+import isEqual from 'lodash/isEqual';
+import packageJson from '../../../package.json';
+import {
+  useCoordination,
+  useLoaders,
+  useSetWarning,
+} from '../../app/state/hooks';
+import { COMPONENT_COORDINATION_TYPES } from '../../app/state/coordination';
+import QRCellSetsTable from './QRCellSetsTable';
+import TitleInfo from '../TitleInfo';
+import {
+  treeExportLevelZeroNode,
+  treeExportSet,
+  treeToExpectedCheckedLevel,
+  nodeToLevelDescendantNamePaths,
+  treeToIntersection,
+  treeToUnion,
+  treeToComplement,
+  treeFindNodeByNamePath,
+  treesConflict,
+  nodeTransform,
+  nodeAppendChild,
+  nodePrependChild,
+  nodeInsertChild,
+  filterNode,
+  treeInitialize,
+  initializeCellSetColor,
+} from './cell-set-utils';
+import {
+  isEqualOrPrefix,
+  tryRenamePath,
+  PATH_SEP,
+} from './utils';
+import {
+  downloadForUser,
+  handleExportJSON,
+  handleExportTabular,
+  tryUpgradeTreeToLatestSchema,
+} from './io';
+import {
+  FILE_EXTENSION_JSON,
+  FILE_EXTENSION_TABULAR,
+  SETS_DATATYPE_CELL,
+} from './constants';
+import { useUrls, useReady } from '../hooks';
+import {
+  setCellSelection,
+  mergeCellSets,
+  getNextNumberedNodeName,
+} from '../utils';
+import { useCellsData, useCellSetsData } from '../data-hooks';
+import { Component } from '../../app/constants';
+
+const CELL_SETS_DATA_TYPES = ['cells', 'cell-sets'];
+
+/**
+ * A subscriber wrapper around the SetsManager component
+ * for the 'cell' datatype.
+ * @param {object} props
+ * @param {string} props.theme The current theme name.
+ * @param {object} props.coordinationScopes The mapping from coordination types to coordination
+ * scopes.
+ * @param {function} props.removeGridComponent The callback function to pass to TitleInfo,
+ * to call when the component has been removed from the grid.
+ * @param {string} props.title The component title.
+ */
+export default function QRCellSetsTableSubscriber(props) {
+  const {
+    coordinationScopes,
+    removeGridComponent,
+    theme,
+    title = 'Query & Reference Cell Sets',
+  } = props;
+
+  const loaders = useLoaders();
+  const setWarning = useSetWarning();
+
+  // Get "props" from the coordination space.
+  const [{
+    dataset,
+    cellSetSelection,
+    cellSetColor,
+    additionalCellSets,
+    cellColorEncoding,
+  }, {
+    setCellSetSelection,
+    setCellColorEncoding,
+    setCellSetColor,
+    setAdditionalCellSets,
+  }] = useCoordination(
+    COMPONENT_COORDINATION_TYPES[Component.QUERY_REFERENCE_CELL_SETS],
+    coordinationScopes,
+  );
+
+  const [urls, addUrl, resetUrls] = useUrls();
+  const [
+    isReady,
+    setItemIsReady,
+    setItemIsNotReady, // eslint-disable-line no-unused-vars
+    resetReadyItems,
+  ] = useReady(
+    CELL_SETS_DATA_TYPES,
+  );
+
+  const [cellSetExpansion, setCellSetExpansion] = useState([]);
+
+  // Reset file URLs and loader progress when the dataset has changed.
+  useEffect(() => {
+    resetUrls();
+    resetReadyItems();
+    setCellSetExpansion([]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [loaders, dataset]);
+
+  // Get data from loaders using the data hooks.
+  const [cells] = useCellsData(loaders, dataset, setItemIsReady, addUrl, true);
+  const [cellSets] = useCellSetsData(
+    loaders, dataset, setItemIsReady, addUrl, true,
+    { setCellSetSelection, setCellSetColor },
+    { cellSetSelection, cellSetColor },
+  );
+
+  // Validate and upgrade the additionalCellSets.
+  useEffect(() => {
+    if (additionalCellSets) {
+      let upgradedCellSets;
+      try {
+        upgradedCellSets = tryUpgradeTreeToLatestSchema(additionalCellSets, SETS_DATATYPE_CELL);
+      } catch (e) {
+        setWarning(e.message);
+        return;
+      }
+      setAdditionalCellSets(upgradedCellSets);
+    }
+  }, [additionalCellSets, setAdditionalCellSets, setWarning]);
+
+  // Get an array of all cell IDs to use for set complement operations.
+  const allCellIds = useMemo(() => (cells ? Object.keys(cells) : []), [cells]);
+
+  // A helper function for updating the encoding for cell colors,
+  // which may have previously been set to 'geneSelection'.
+  function setCellSetColorEncoding() {
+    setCellColorEncoding('cellSetSelection');
+  }
+
+  // Merged cell sets are only to be used for convenience when reading
+  // (if writing: update either `cellSets` _or_ `additionalCellSets`).
+  const mergedCellSets = useMemo(
+    () => mergeCellSets(cellSets, additionalCellSets),
+    [cellSets, additionalCellSets],
+  );
+
+  // Infer the state of the "checked level" radio button based on the selected cell sets.
+  const checkedLevel = useMemo(() => {
+    if (cellSetSelection && cellSetSelection.length > 0
+    && mergedCellSets && mergedCellSets.tree.length > 0) {
+      return treeToExpectedCheckedLevel(mergedCellSets, cellSetSelection);
+    }
+    return null;
+  }, [cellSetSelection, mergedCellSets]);
+
+  // Callback functions
+
+  // The user wants to select all nodes at a particular hierarchy level.
+  function onCheckLevel(levelZeroName, levelIndex) {
+    const lzn = mergedCellSets.tree.find(n => n.name === levelZeroName);
+    if (lzn) {
+      const newCellSetSelection = nodeToLevelDescendantNamePaths(lzn, levelIndex, [], true);
+      setCellSetSelection(newCellSetSelection);
+      setCellSetColorEncoding();
+    }
+  }
+
+  // The user wants to check or uncheck a cell set node.
+  function onCheckNode(targetKey, checked) {
+    const targetPath = (Array.isArray(targetKey) ? targetKey : targetKey.split(PATH_SEP));
+    if (!targetKey) {
+      return;
+    }
+    if (checked) {
+      setCellSetSelection([...cellSetSelection, targetPath]);
+    } else {
+      setCellSetSelection(cellSetSelection.filter(d => !isEqual(d, targetPath)));
+    }
+    setCellSetColorEncoding();
+  }
+
+  // The user wants to expand or collapse a node in the tree.
+  function onExpandNode(expandedKeys, targetKey, expanded) {
+    if (expanded) {
+      setCellSetExpansion(prev => ([...prev, targetKey.split(PATH_SEP)]));
+    } else {
+      setCellSetExpansion(prev => prev.filter(d => !isEqual(d, targetKey.split(PATH_SEP))));
+    }
+  }
+
+  // The user dragged a tree node and dropped it somewhere else in the tree
+  // to re-arrange or re-order the nodes.
+  // We need to verify that their drop target is valid, and if so, complete
+  // the tree re-arrangement.
+  function onDropNode(dropKey, dragKey, dropPosition, dropToGap) {
+    const dropPath = dropKey.split(PATH_SEP);
+    const dropNode = treeFindNodeByNamePath(additionalCellSets, dropPath);
+    if (!dropNode.children && !dropToGap) {
+      // Do not allow a node with a set (i.e. leaf) to become a child of another node with a set,
+      // as this will result in an internal node having a set, which we do not allow.
+      return;
+    }
+    const dropNodeLevel = dropPath.length - 1;
+    const dropNodeIsLevelZero = dropNodeLevel === 0;
+
+    // Get drag node.
+    const dragPath = dragKey.split(PATH_SEP);
+    const dragNode = treeFindNodeByNamePath(additionalCellSets, dragPath);
+
+    if (dropNodeIsLevelZero && dropToGap && !dragNode.children) {
+      // Do not allow a leaf node to become a level zero node.
+      return;
+    }
+
+    let dropParentNode;
+    let dropParentPath;
+    let dropNodeCurrIndex;
+    if (!dropNodeIsLevelZero) {
+      dropParentPath = dropPath.slice(0, -1);
+      dropParentNode = treeFindNodeByNamePath(additionalCellSets, dropParentPath);
+      dropNodeCurrIndex = dropParentNode.children.findIndex(c => c.name === dropNode.name);
+    } else {
+      dropNodeCurrIndex = additionalCellSets.tree.findIndex(
+        lzn => lzn.name === dropNode.name,
+      );
+    }
+    // Further, only allow dragging if the dragged node will have a unique
+    // name among its new siblings.
+    let hasSiblingNameConflict;
+    const dragNodeName = dragNode.name;
+    if (!dropNodeIsLevelZero && dropToGap) {
+      hasSiblingNameConflict = dropParentNode.children
+        .find(c => c !== dragNode && c.name === dragNodeName);
+    } else if (!dropToGap) {
+      hasSiblingNameConflict = dropNode.children
+        .find(c => c !== dragNode && c.name === dragNodeName);
+    } else {
+      hasSiblingNameConflict = additionalCellSets.tree
+        .find(lzn => lzn !== dragNode && lzn.name === dragNodeName);
+    }
+
+    if (hasSiblingNameConflict) {
+      return;
+    }
+
+    // Remove the dragged object from its current position.
+    // Recursively check whether each node path
+    // matches the path of the node to delete.
+    // If so, return null, and then always use
+    // .filter(Boolean) to eliminate any null array elements.
+    const nextAdditionalCellSets = {
+      ...additionalCellSets,
+      tree: additionalCellSets.tree.map(lzn => filterNode(lzn, [], dragPath)).filter(Boolean),
+    };
+
+    // Update index values after temporarily removing the dragged node.
+    // Names are unique as children of their parents.
+    if (!dropNodeIsLevelZero) {
+      dropNodeCurrIndex = dropParentNode.children.findIndex(c => c.name === dropNode.name);
+    } else {
+      dropNodeCurrIndex = nextAdditionalCellSets.tree.findIndex(
+        lzn => lzn.name === dropNode.name,
+      );
+    }
+    let newDragPath = [];
+    if (!dropToGap || !dropNodeIsLevelZero) {
+      let addChildFunction;
+      let checkPathFunction;
+      const newPath = [];
+      if (!dropToGap) {
+        // Append the dragNode to dropNode's children if dropping _onto_ the dropNode.
+        // Set dragNode as the last child of dropNode.
+        addChildFunction = n => nodeAppendChild(n, dragNode);
+        checkPathFunction = path => isEqual(path, dropPath);
+      } else if (!dropNodeIsLevelZero) {
+        // Prepend or insert the dragNode if dropping _between_ (above or below dropNode).
+        // The dropNode is at a level greater than zero,
+        // so it has a parent.
+        checkPathFunction = path => isEqual(path, dropParentPath);
+        if (dropPosition === -1) {
+          // Set dragNode as first child of dropParentNode.
+          addChildFunction = n => nodePrependChild(n, dragNode);
+        } else {
+          // Set dragNode before or after dropNode.
+          const insertIndex = dropNodeCurrIndex + (dropPosition > dropNodeCurrIndex ? 1 : 0);
+          addChildFunction = n => nodeInsertChild(n, dragNode, insertIndex);
+        }
+      }
+      nextAdditionalCellSets.tree = nextAdditionalCellSets.tree.map(
+        node => nodeTransform(
+          node,
+          (n, path) => checkPathFunction(path),
+          (n) => {
+            const newNode = addChildFunction(n);
+            return newNode;
+          },
+          newPath,
+        ),
+      );
+      // Done
+      setAdditionalCellSets(nextAdditionalCellSets);
+      newDragPath = [...newPath[0], dragNode.name];
+      setCellSetSelection([newDragPath]);
+    } else if (dropPosition === -1) {
+      // We need to drop the dragNode to level zero,
+      // and level zero nodes do not have parents.
+      // Set dragNode as first level zero node of the tree.
+      nextAdditionalCellSets.tree.unshift(dragNode);
+      setAdditionalCellSets(nextAdditionalCellSets);
+      newDragPath = [dragNode.name];
+      setCellSetSelection([newDragPath]);
+    } else {
+      // Set dragNode before or after dropNode in level zero.
+      const insertIndex = dropNodeCurrIndex + (dropPosition > dropNodeCurrIndex ? 1 : 0);
+      const newLevelZero = Array.from(nextAdditionalCellSets.tree);
+      newLevelZero.splice(insertIndex, 0, dragNode);
+      nextAdditionalCellSets.tree = newLevelZero;
+      setAdditionalCellSets(nextAdditionalCellSets);
+      newDragPath = [dragNode.name];
+      setCellSetSelection([newDragPath]);
+    }
+    const oldColors = cellSetColor.filter(
+      i => isEqualOrPrefix(dragPath, i.path),
+    );
+    const newColors = oldColors.map(
+      i => (
+        {
+          ...i,
+          path: !isEqual(i.path, dragPath)
+            ? newDragPath.concat(i.path.slice(dragPath.length))
+            : newDragPath,
+        }
+      ),
+    );
+    const newCellSetColor = cellSetColor.filter(
+      i => !isEqualOrPrefix(dragPath, i.path),
+    );
+    newCellSetColor.push(...newColors);
+    setCellSetColor(newCellSetColor);
+  }
+
+  // The user wants to change the color of a cell set node.
+  function onNodeSetColor(targetPath, color) {
+    // Replace the color if an array element for this path already exists.
+    const prevNodeColor = cellSetColor?.find(d => isEqual(d.path, targetPath));
+    if (!prevNodeColor) {
+      setCellSetColor([
+        ...(cellSetColor || []),
+        {
+          path: targetPath,
+          color,
+        },
+      ]);
+    } else {
+      setCellSetColor([
+        ...cellSetColor.filter(d => !isEqual(d.path, targetPath)),
+        {
+          path: targetPath,
+          color,
+        },
+      ]);
+    }
+  }
+
+  // The user wants to change the name of a cell set node.
+  function onNodeSetName(targetPath, name) {
+    const nextNamePath = [...targetPath];
+    nextNamePath.pop();
+    nextNamePath.push(name);
+
+    // Recursively check whether each node path
+    // matches the path or a prefix of the path of the node to rename.
+    // If so, rename the node using the new path.
+    function renameNode(node, prevPath) {
+      if (isEqual([...prevPath, node.name], targetPath)) {
+        return {
+          ...node,
+          name,
+        };
+      }
+      if (!node.children) {
+        return node;
+      }
+      return {
+        ...node,
+        children: node.children.map(c => renameNode(c, [...prevPath, node.name])),
+      };
+    }
+    const nextAdditionalCellSets = {
+      ...additionalCellSets,
+      tree: additionalCellSets.tree.map(lzn => renameNode(lzn, [])),
+    };
+    // Change all paths that have this node as a prefix (i.e. descendants).
+    const nextCellSetColor = cellSetColor.map(d => ({
+      path: tryRenamePath(targetPath, d.path, nextNamePath),
+      color: d.color,
+    }));
+    const nextCellSetSelection = cellSetSelection.map(d => (
+      tryRenamePath(targetPath, d, nextNamePath)
+    ));
+    const nextCellSetExpansion = cellSetExpansion.map(d => (
+      tryRenamePath(targetPath, d, nextNamePath)
+    ));
+    // Need to update the node path everywhere it may be present.
+    setAdditionalCellSets(nextAdditionalCellSets);
+    setCellSetColor(nextCellSetColor);
+    setCellSetSelection(nextCellSetSelection);
+    setCellSetExpansion(nextCellSetExpansion);
+  }
+
+  // Each time the user types while renaming a cell set node,
+  // we need to check whether the potential new name conflicts
+  // with any existing cell set node names.
+  // If there are conflicts, we want to disable the "Save" button.
+  function onNodeCheckNewName(targetPath, name) {
+    const nextNamePath = [...targetPath];
+    nextNamePath.pop();
+    nextNamePath.push(name);
+    const hasConflicts = (
+      !isEqual(targetPath, nextNamePath)
+      && treeFindNodeByNamePath(additionalCellSets, nextNamePath)
+    );
+    return hasConflicts;
+  }
+
+  // The user wants to delete a cell set node, and has confirmed their choice.
+  function onNodeRemove(targetPath) {
+    // Recursively check whether each node path
+    // matches the path of the node to delete.
+    // If so, return null, and then always use
+    // .filter(Boolean) to eliminate any null array elements.
+    const nextAdditionalCellSets = {
+      ...additionalCellSets,
+      tree: additionalCellSets.tree.map(lzn => filterNode(lzn, [], targetPath)).filter(Boolean),
+    };
+    // Delete state for all paths that have this node
+    // path as a prefix (i.e. delete all descendents).
+    const nextCellSetColor = cellSetColor.filter(d => !isEqualOrPrefix(targetPath, d.path));
+    const nextCellSetSelection = cellSetSelection.filter(d => !isEqualOrPrefix(targetPath, d));
+    const nextCellSetExpansion = cellSetExpansion.filter(d => !isEqualOrPrefix(targetPath, d));
+    setAdditionalCellSets(nextAdditionalCellSets);
+    setCellSetColor(nextCellSetColor);
+    setCellSetSelection(nextCellSetSelection);
+    setCellSetExpansion(nextCellSetExpansion);
+  }
+
+  // The user wants to view (i.e. select) a particular node,
+  // or its expanded descendents.
+  function onNodeView(targetPath) {
+    // If parent node is clicked, and if it is expanded,
+    // then select the expanded descendent nodes.
+    const setsToView = [];
+    // Recursively determine which descendent nodes are currently expanded.
+    function viewNode(node, nodePath) {
+      if (cellSetExpansion.find(expandedPath => isEqual(nodePath, expandedPath))) {
+        if (node.children) {
+          node.children.forEach((c) => {
+            viewNode(c, [...nodePath, c.name]);
+          });
+        } else {
+          setsToView.push(nodePath);
+        }
+      } else {
+        setsToView.push(nodePath);
+      }
+    }
+    const targetNode = treeFindNodeByNamePath(mergedCellSets, targetPath);
+    viewNode(targetNode, targetPath);
+    setCellSetSelection(setsToView);
+    setCellSetColorEncoding();
+  }
+
+  // The user wants to create a new level zero node.
+  function onCreateLevelZeroNode() {
+    const nextName = getNextNumberedNodeName(additionalCellSets?.tree, 'My hierarchy ');
+    setAdditionalCellSets({
+      ...(additionalCellSets || treeInitialize(SETS_DATATYPE_CELL)),
+      tree: [
+        ...(additionalCellSets ? additionalCellSets.tree : []),
+        {
+          name: nextName,
+          children: [],
+        },
+      ],
+    });
+  }
+
+  // The user wants to create a new node corresponding to
+  // the union of the selected sets.
+  function onUnion() {
+    const newSet = treeToUnion(mergedCellSets, cellSetSelection);
+    setCellSelection(
+      newSet, additionalCellSets, cellSetColor,
+      setCellSetSelection, setAdditionalCellSets, setCellSetColor,
+      setCellColorEncoding,
+      'Union ',
+    );
+  }
+
+  // The user wants to create a new node corresponding to
+  // the intersection of the selected sets.
+  function onIntersection() {
+    const newSet = treeToIntersection(mergedCellSets, cellSetSelection);
+    setCellSelection(
+      newSet, additionalCellSets, cellSetColor,
+      setCellSetSelection, setAdditionalCellSets, setCellSetColor,
+      setCellColorEncoding,
+      'Intersection ',
+    );
+  }
+
+  // The user wants to create a new node corresponding to
+  // the complement of the selected sets.
+  function onComplement() {
+    const newSet = treeToComplement(mergedCellSets, cellSetSelection, allCellIds);
+    setCellSelection(
+      newSet, additionalCellSets, cellSetColor,
+      setCellSetSelection, setAdditionalCellSets, setCellSetColor,
+      setCellColorEncoding,
+      'Complement ',
+    );
+  }
+
+  // The user wants to import a cell set hierarchy,
+  // probably from a CSV or JSON file.
+  function onImportTree(treeToImport) {
+    // Check for any naming conflicts with the current sets
+    // (both user-defined and dataset-defined) before importing.
+    const hasConflict = treesConflict(mergedCellSets, treeToImport);
+    if (!hasConflict) {
+      setAdditionalCellSets({
+        ...(additionalCellSets || treeInitialize(SETS_DATATYPE_CELL)),
+        tree: [
+          ...(additionalCellSets ? additionalCellSets.tree : []),
+          ...treeToImport.tree,
+        ],
+      });
+      // Automatically initialize set colors for the imported sets.
+      const importAutoSetColors = initializeCellSetColor(treeToImport, cellSetColor);
+      setCellSetColor([
+        ...cellSetColor,
+        ...importAutoSetColors,
+      ]);
+    }
+  }
+
+  // The user wants to download a particular hierarchy to a JSON file.
+  function onExportLevelZeroNodeJSON(nodePath) {
+    const {
+      treeToExport, nodeName,
+    } = treeExportLevelZeroNode(mergedCellSets, nodePath, SETS_DATATYPE_CELL, cellSetColor, theme);
+    downloadForUser(
+      handleExportJSON(treeToExport),
+      `${nodeName}_${packageJson.name}-${SETS_DATATYPE_CELL}-hierarchy.${FILE_EXTENSION_JSON}`,
+    );
+  }
+
+  // The user wants to download a particular hierarchy to a CSV file.
+  function onExportLevelZeroNodeTabular(nodePath) {
+    const {
+      treeToExport, nodeName,
+    } = treeExportLevelZeroNode(mergedCellSets, nodePath, SETS_DATATYPE_CELL, cellSetColor, theme);
+    downloadForUser(
+      handleExportTabular(treeToExport),
+      `${nodeName}_${packageJson.name}-${SETS_DATATYPE_CELL}-hierarchy.${FILE_EXTENSION_TABULAR}`,
+    );
+  }
+
+  // The user wants to download a particular set to a JSON file.
+  function onExportSetJSON(nodePath) {
+    const { setToExport, nodeName } = treeExportSet(mergedCellSets, nodePath);
+    downloadForUser(
+      handleExportJSON(setToExport),
+      `${nodeName}_${packageJson.name}-${SETS_DATATYPE_CELL}-set.${FILE_EXTENSION_JSON}`,
+      FILE_EXTENSION_JSON,
+    );
+  }
+  return (
+    <TitleInfo
+      title={title}
+      isScroll
+      removeGridComponent={removeGridComponent}
+      urls={urls}
+      theme={theme}
+      isReady={isReady}
+    >
+      <QRCellSetsTable
+        setColor={cellSetColor}
+        sets={cellSets}
+        additionalSets={additionalCellSets}
+        levelSelection={checkedLevel}
+        setSelection={cellSetSelection}
+        setExpansion={cellSetExpansion}
+        hasColorEncoding={cellColorEncoding === 'cellSetSelection'}
+        draggable
+        datatype={SETS_DATATYPE_CELL}
+        onError={setWarning}
+        onCheckNode={onCheckNode}
+        onExpandNode={onExpandNode}
+        onDropNode={onDropNode}
+        onCheckLevel={onCheckLevel}
+        onNodeSetColor={onNodeSetColor}
+        onNodeSetName={onNodeSetName}
+        onNodeCheckNewName={onNodeCheckNewName}
+        onNodeRemove={onNodeRemove}
+        onNodeView={onNodeView}
+        onImportTree={onImportTree}
+        onCreateLevelZeroNode={onCreateLevelZeroNode}
+        onExportLevelZeroNodeJSON={onExportLevelZeroNodeJSON}
+        onExportLevelZeroNodeTabular={onExportLevelZeroNodeTabular}
+        onExportSetJSON={onExportSetJSON}
+        onUnion={onUnion}
+        onIntersection={onIntersection}
+        onComplement={onComplement}
+        hasCheckedSetsToUnion={cellSetSelection?.length > 1}
+        hasCheckedSetsToIntersect={cellSetSelection?.length > 1}
+        hasCheckedSetsToComplement={cellSetSelection?.length > 0}
+        theme={theme}
+      />
+    </TitleInfo>
+  );
+}

--- a/src/components/sets/index.js
+++ b/src/components/sets/index.js
@@ -2,3 +2,5 @@ export { default as CellSetsManagerSubscriber } from './CellSetsManagerSubscribe
 export { default as SetsManager } from './SetsManager';
 export { default as CellSetSizesPlot } from './CellSetSizesPlot';
 export { default as CellSetSizesPlotSubscriber } from './CellSetSizesPlotSubscriber';
+export { default as QRCellSetsTableSubscriber } from './QRCellSetsTableSubscriber';
+export { default as QRCellSetsTable } from './QRCellSetsTable';

--- a/src/demo/view-configs/eng.js
+++ b/src/demo/view-configs/eng.js
@@ -72,7 +72,7 @@ export const eng2019 = {
       h: 2,
     },
     {
-      component: 'cellSets',
+      component: 'queryReferenceCellSets',
       x: 9,
       y: 4,
       w: 3,


### PR DESCRIPTION
This is an example of creating a new component by copying an existing component.
#### Change List
- Add a new component name `queryReferenceCellSets` in `src/app/constants.js`
- Copy `src/components/sets/SetsManager.js` to`src/components/sets/QRCellSetsTable.js` 
- Copy `src/components/sets/CellSetsManagerSubscriber.js` to`src/components/sets/QRCellSetsTableSubscriber.js` 
- Change the imported inner component from `SetsManager` to `QRCellSetsTable` in `QRCellSetsTableSubscriber`
- Add the component to `src/app/component-registry.js` so that it can be used
- Copy the list of coordination types used by the `cellSets` component (in `src/app/state/coordination.js`)
- Update the demo at `http://localhost:3000/?dataset=eng-2019&theme=light` by changing `cellSets` to `queryReferenceCellSets` in `src/demo/view-configs/eng.js`
